### PR TITLE
Adds a mailmap to correct legacy attribution

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Cyrus Boadway <cyrus@boadway.ca> sailing.instructor <devnull@localhost>
+


### PR DESCRIPTION
Since the transfer from google code hosting to github, I'm sure there are several contributors who wouldn't mind updating the attribution of their contributions. A [`.mailmap`](https://schacon.github.io/git/git-shortlog.html#_mapping_authors) file is the solution.
